### PR TITLE
make source host configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The whole core code for this plugin wont pass the 300 lines of code mark, and I 
       options: {
         host: 'your.graylog.server.url',        // <-- defaults to 'localhost'
         port: 12203,                            // <-- defaults to 12202
-        source: 'your-apps-id.server.url'       // <-- defaults to os.hostname()
+        source: 'your-apps-id.server.url',      // <-- defaults to os.hostname()
         config: {
           MAX_BUFFER_SIZE: 700,                 // <-- defaults to 1350
           COMPRESS: true                        // <-- defaults to true
@@ -138,6 +138,7 @@ Also, the second argument accepts an object, you can send anything you want, the
 
 * host - String
 * port - Integer
+* source - String - Defaults to `os.hostname()`, allows to override the source of logs appearing in graylog. 
 * config - Object
     * MAX_BUFFER_SIZE - Integer
     * COMPRESS - Boolean

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ The whole core code for this plugin wont pass the 300 lines of code mark, and I 
       options: {
         host: 'your.graylog.server.url',        // <-- defaults to 'localhost'
         port: 12203,                            // <-- defaults to 12202
+        source: 'your-apps-id.server.url'       // <-- defaults to os.hostname()
         config: {
-          MAX_BUFFER_SIZE: 700,                  // <-- defaults to 1350
+          MAX_BUFFER_SIZE: 700,                 // <-- defaults to 1350
           COMPRESS: true                        // <-- defaults to true
         }
       }
@@ -121,15 +122,15 @@ Also, the second argument accepts an object, you can send anything you want, the
 
 ```javascript
     server.start((err) => {
-    
+
       if (err) {
         throw err
       }
-    
+
       console.log(`Server running at: ${server.info.uri}`)
       server.log('info', {server_message: 'server started at' + server.info.uri}) // <-- This will send a GELF Message
                                                                                   //     to the graylogserver.
-    
+
     })
 ```
 
@@ -178,4 +179,3 @@ The test scripts are:
 `test-integration` - Runs a local hapi.js server instance, if you fire a GET request at the '/log' endpoint, it will fire a GELF message to the graylog local server
 
 All tests generate a coverage report.
-

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict'
-
+const os = require('os')
 const UDPInterface = require('./lib/sending-interfaces/udp')
 const gelfFactory = require('./lib/gelf/index')
 
 let internals = {
   sendGelfMessage: function (tag, data, options) {
     try {
-      const gelfPayload = gelfFactory(data, tag)
+      const gelfPayload = gelfFactory(data, tag, options.source)
       const udpSender = new UDPInterface(
         gelfPayload,
         options.config,
@@ -32,6 +32,8 @@ let internals = {
 }
 
 exports.register = function (server, options, next) {
+  options.source = options.source ? options.source : os.hostname()
+
   const serverLogHandler = internals.pluginFactory('server', options)
   const requestLogHandler = internals.pluginFactory('request', options)
   server.on('log', serverLogHandler)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const gelfFactory = require('./lib/gelf/index')
 let internals = {
   sendGelfMessage: function (tag, data, options) {
     try {
-      const gelfPayload = gelfFactory(data, tag, options.source)
+      data.source = options.source
+      const gelfPayload = gelfFactory(data, tag)
       const udpSender = new UDPInterface(
         gelfPayload,
         options.config,

--- a/lib/gelf/index.js
+++ b/lib/gelf/index.js
@@ -1,10 +1,9 @@
 'use strict'
 
 const _ = require('lodash')
-const os = require('os')
 
 // http://docs.graylog.org/en/2.3/pages/gelf.html
-function GELFMessageFactory (logObject, tag) {
+function GELFMessageFactory (logObject, tag, source) {
   // Libraries SHOULD not allow to send id as additional field (_id).
   if(logObject) {
     delete logObject.id
@@ -14,7 +13,7 @@ function GELFMessageFactory (logObject, tag) {
   // GELF spec string (UTF-8) host - MUST be set by client library.
   const gelfRequiredFields = {
     'version': '1.1',
-    'host': os.hostname(),
+    'host': source,
     'level': parseLevel(tag),
     'short_message': setShortMessage(logObject)
   }

--- a/lib/gelf/index.js
+++ b/lib/gelf/index.js
@@ -3,7 +3,7 @@
 const _ = require('lodash')
 
 // http://docs.graylog.org/en/2.3/pages/gelf.html
-function GELFMessageFactory (logObject, tag, source) {
+function GELFMessageFactory (logObject, tag) {
   // Libraries SHOULD not allow to send id as additional field (_id).
   if(logObject) {
     delete logObject.id
@@ -13,10 +13,13 @@ function GELFMessageFactory (logObject, tag, source) {
   // GELF spec string (UTF-8) host - MUST be set by client library.
   const gelfRequiredFields = {
     'version': '1.1',
-    'host': source,
+    'host': logObject.source,
     'level': parseLevel(tag),
     'short_message': setShortMessage(logObject)
   }
+  // inserted already above.
+  delete logObject.source
+
   return _.assign(gelfRequiredFields, addUnderscoreToAdditionalFields(logObject))
 }
 

--- a/lib/sending-interfaces/udp.js
+++ b/lib/sending-interfaces/udp.js
@@ -19,12 +19,12 @@ function UDPInterface (
   gelfServerPort = 12202,
   gelfServerHost = 'localhost'
 ) {
-  this.gelfObject         = gelfObject
-  this.gelfArrayToBeSent  = []
-  this.gelfServerHost     = gelfServerHost
-  this.gelfServerPort     = gelfServerPort
-  this.options            = options
-  this.socket             = dgram.createSocket('udp4')
+  this.gelfObject        = gelfObject
+  this.gelfArrayToBeSent = []
+  this.gelfServerHost    = gelfServerHost
+  this.gelfServerPort    = gelfServerPort
+  this.options           = options
+  this.socket            = dgram.createSocket('udp4')
 }
 
 UDPInterface.prototype.prepareGelfBuffer = async function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hsl-graylog-plugin",
+  "name": "hapi-graylog",
   "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/test/unit/gelf.js
+++ b/test/unit/gelf.js
@@ -7,7 +7,7 @@ const GelfFactory = require(path.resolve('lib/gelf/index.js'))
 
 test('GelfFactory should create basic gelf message with short and detailed message', (t) => {
   t.plan(1)
-  const gelfJson = GelfFactory()
+  const gelfJson = GelfFactory({}, '5', os.hostname())
   const gelfRequiredFields = {
     'version': '1.1',
     'host': os.hostname(),
@@ -19,7 +19,7 @@ test('GelfFactory should create basic gelf message with short and detailed messa
 
 test('GelfFactory should create gelf message with data', (t) => {
   t.plan(1)
-  const gelfJson = GelfFactory({facility: 'some facility', full_message: 'some full message', short_message: 'some short message'}, 'notice')
+  const gelfJson = GelfFactory({facility: 'some facility', full_message: 'some full message', short_message: 'some short message'}, 'notice', os.hostname())
   const gelfExpectedJson = {
     'version': '1.1',
     'host': os.hostname(),
@@ -33,7 +33,7 @@ test('GelfFactory should create gelf message with data', (t) => {
 
 test('GelfFactory should delete id key', (t) => {
   t.plan(1)
-  const gelfJson = GelfFactory({facility: 'some facility', full_message: 'some full message', id: '1', short_message: 'some short message'}, 'notice')
+  const gelfJson = GelfFactory({facility: 'some facility', full_message: 'some full message', id: '1', short_message: 'some short message'}, 'notice', os.hostname())
   const gelfExpectedJson = {
     'version': '1.1',
     'host': os.hostname(),
@@ -47,56 +47,56 @@ test('GelfFactory should delete id key', (t) => {
 
 test('Testing tags', (t) => {
   t.plan(8)
-  const gelfJsonEmergency = GelfFactory({}, 'emergency')
+  const gelfJsonEmergency = GelfFactory({}, 'emergency', os.hostname())
   const gelfExpectedJsonEmergency = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 0,
     'short_message': 'short_message not set',
   }
-  const gelfJsonAlert = GelfFactory({}, 'alert')
+  const gelfJsonAlert = GelfFactory({}, 'alert', os.hostname())
   const gelfExpectedJsonAlert = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 1,
     'short_message': 'short_message not set',
   }
-  const gelfJsonCritical = GelfFactory({}, 'critical')
+  const gelfJsonCritical = GelfFactory({}, 'critical', os.hostname())
   const gelfExpectedJsonCritical = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 2,
     'short_message': 'short_message not set',
   }
-  const gelfJsonError = GelfFactory({}, 'error')
+  const gelfJsonError = GelfFactory({}, 'error', os.hostname())
   const gelfExpectedJsonError = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 3,
     'short_message': 'short_message not set',
   }
-  const gelfJsonWarning = GelfFactory({}, 'warning')
+  const gelfJsonWarning = GelfFactory({}, 'warning', os.hostname())
   const gelfExpectedJsonWarning= {
     'version': '1.1',
     'host': os.hostname(),
     'level': 4,
     'short_message': 'short_message not set',
   }
-  const gelfJsonNotice = GelfFactory({}, 'notice')
+  const gelfJsonNotice = GelfFactory({}, 'notice', os.hostname())
   const gelfExpectedJsonNotice= {
     'version': '1.1',
     'host': os.hostname(),
     'level': 5,
     'short_message': 'short_message not set',
   }
-  const gelfJsonInfo = GelfFactory({}, 'info')
+  const gelfJsonInfo = GelfFactory({}, 'info', os.hostname())
   const gelfExpectedJsonInfo= {
     'version': '1.1',
     'host': os.hostname(),
     'level': 6,
     'short_message': 'short_message not set',
   }
-  const gelfJsonDebug = GelfFactory({}, 'debug')
+  const gelfJsonDebug = GelfFactory({}, 'debug', os.hostname())
   const gelfExpectedJsonDebug= {
     'version': '1.1',
     'host': os.hostname(),

--- a/test/unit/gelf.js
+++ b/test/unit/gelf.js
@@ -7,7 +7,7 @@ const GelfFactory = require(path.resolve('lib/gelf/index.js'))
 
 test('GelfFactory should create basic gelf message with short and detailed message', (t) => {
   t.plan(1)
-  const gelfJson = GelfFactory({}, '5', os.hostname())
+  const gelfJson = GelfFactory({source: os.hostname(), }, '5')
   const gelfRequiredFields = {
     'version': '1.1',
     'host': os.hostname(),
@@ -19,7 +19,7 @@ test('GelfFactory should create basic gelf message with short and detailed messa
 
 test('GelfFactory should create gelf message with data', (t) => {
   t.plan(1)
-  const gelfJson = GelfFactory({facility: 'some facility', full_message: 'some full message', short_message: 'some short message'}, 'notice', os.hostname())
+  const gelfJson = GelfFactory({source: os.hostname(), facility: 'some facility', full_message: 'some full message', short_message: 'some short message'}, 'notice')
   const gelfExpectedJson = {
     'version': '1.1',
     'host': os.hostname(),
@@ -33,7 +33,7 @@ test('GelfFactory should create gelf message with data', (t) => {
 
 test('GelfFactory should delete id key', (t) => {
   t.plan(1)
-  const gelfJson = GelfFactory({facility: 'some facility', full_message: 'some full message', id: '1', short_message: 'some short message'}, 'notice', os.hostname())
+  const gelfJson = GelfFactory({source: os.hostname(), facility: 'some facility', full_message: 'some full message', id: '1', short_message: 'some short message'}, 'notice')
   const gelfExpectedJson = {
     'version': '1.1',
     'host': os.hostname(),
@@ -47,56 +47,56 @@ test('GelfFactory should delete id key', (t) => {
 
 test('Testing tags', (t) => {
   t.plan(8)
-  const gelfJsonEmergency = GelfFactory({}, 'emergency', os.hostname())
+  const gelfJsonEmergency = GelfFactory({source: os.hostname(), }, 'emergency')
   const gelfExpectedJsonEmergency = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 0,
     'short_message': 'short_message not set',
   }
-  const gelfJsonAlert = GelfFactory({}, 'alert', os.hostname())
+  const gelfJsonAlert = GelfFactory({source: os.hostname(), }, 'alert')
   const gelfExpectedJsonAlert = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 1,
     'short_message': 'short_message not set',
   }
-  const gelfJsonCritical = GelfFactory({}, 'critical', os.hostname())
+  const gelfJsonCritical = GelfFactory({source: os.hostname(), }, 'critical')
   const gelfExpectedJsonCritical = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 2,
     'short_message': 'short_message not set',
   }
-  const gelfJsonError = GelfFactory({}, 'error', os.hostname())
+  const gelfJsonError = GelfFactory({source: os.hostname(), }, 'error')
   const gelfExpectedJsonError = {
     'version': '1.1',
     'host': os.hostname(),
     'level': 3,
     'short_message': 'short_message not set',
   }
-  const gelfJsonWarning = GelfFactory({}, 'warning', os.hostname())
+  const gelfJsonWarning = GelfFactory({source: os.hostname(), }, 'warning')
   const gelfExpectedJsonWarning= {
     'version': '1.1',
     'host': os.hostname(),
     'level': 4,
     'short_message': 'short_message not set',
   }
-  const gelfJsonNotice = GelfFactory({}, 'notice', os.hostname())
+  const gelfJsonNotice = GelfFactory({source: os.hostname(), }, 'notice')
   const gelfExpectedJsonNotice= {
     'version': '1.1',
     'host': os.hostname(),
     'level': 5,
     'short_message': 'short_message not set',
   }
-  const gelfJsonInfo = GelfFactory({}, 'info', os.hostname())
+  const gelfJsonInfo = GelfFactory({source: os.hostname(), }, 'info')
   const gelfExpectedJsonInfo= {
     'version': '1.1',
     'host': os.hostname(),
     'level': 6,
     'short_message': 'short_message not set',
   }
-  const gelfJsonDebug = GelfFactory({}, 'debug', os.hostname())
+  const gelfJsonDebug = GelfFactory({source: os.hostname(), }, 'debug')
   const gelfExpectedJsonDebug= {
     'version': '1.1',
     'host': os.hostname(),


### PR DESCRIPTION
When running hapi on dynamic servers (e.g. cloud provided hosts), `os.hostname()` is not distinguishing the source enough. Making this configurable is similar to what other graylog libraries provide.